### PR TITLE
Add Stimulus controller support

### DIFF
--- a/app/javascript/spree_vetfort_extension_v5/controllers/hello_controller.js
+++ b/app/javascript/spree_vetfort_extension_v5/controllers/hello_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    console.log("Hello from SpreeVetfortExtensionV5 Stimulus controller")
+  }
+}

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,5 @@
+pin_all_from SpreeVetfortExtensionV5::Engine.root.join("app/javascript/spree_vetfort_extension_v5/controllers"),
+             under: "spree_vetfort_extension_v5/controllers",
+             to: "spree_vetfort_extension_v5/controllers"
+
+draw Spree::Core::Engine.root.join("config/importmap.rb")

--- a/lib/spree_vetfort_extension_v5/engine.rb
+++ b/lib/spree_vetfort_extension_v5/engine.rb
@@ -13,6 +13,12 @@ module SpreeVetfortExtensionV5
       SpreeVetfortExtensionV5::Config = SpreeVetfortExtensionV5::Configuration.new
     end
 
+    initializer 'spree_vetfort_extension_v5.importmap', before: 'importmap' do |app|
+      app.config.importmap.paths << root.join('config/importmap.rb')
+      # https://github.com/rails/importmap-rails?tab=readme-ov-file#sweeping-the-cache-in-development-and-test
+      app.config.importmap.cache_sweepers << root.join('app/javascript')
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)


### PR DESCRIPTION
## Summary
- add Stimulus controller folder with a sample controller
- provide importmap configuration for the extension
- register importmap paths in the engine initializer

## Testing
- `bundle exec rake spec` *(fails: The git source https://github.com/spree/spree.git is not yet checked out)*

------
https://chatgpt.com/codex/tasks/task_e_6849d779f79883228ae11b9d3e7075e8